### PR TITLE
[Fixes: #25] Remove support for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,11 @@ setup(
     author_email='glen@glenjarvis.com',
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37
+envlist = py36,py37
 
 [testenv]
 


### PR DESCRIPTION
Issue: https://github.com/glenjarvis/badgr-lite/issues

Sphinx 2.2.0 support has dependencies. Following these dependencies
shows a downstream dependency of snowballstemmer. That dependency is
allowed to any upper limit.

However, a new upgrade of snowballstemmer to 2.0.0 fails.

It fails because it's downstream dependency of yarl requires Python
3.6+:

RuntimeError: yarl 1.4+ requires Python 3.6+

https://travis-ci.org/glenjarvis/badgr-lite/jobs/592955050

Until this is untangled in the dependent libraries, let's remove support
for anything below 3.6. This will, if nothing else, at least communicate
to the consumers what will work.