### PR TITLE
Remove Travis support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - 3.7
   - 3.6
-  - 3.5
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 #install: pip install -U tox-travis

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,24 @@ Automate awarding Open Badges to recipients without the overhead of a server
      :alt: Updates
 
 
+Python support
+--------------
+
+The actual library should work in Python 3.5, 3.6 and 3.7. However, the
+development support for documentation (i.e., Sphinx) has removed Python 3.5
+support.
+
+The Sphinx library requires snowballstemmer >= 1.1. However, snowballstemmer
+2.0.0 was just released. That update to snowballtemmer fails with Python 3.5
+due to a dependency with Python 3.6 or higher:
+
+```RuntimeError: yarl 1.4+ requires Python 3.6+```
+
+Until this is resolved with the Sphinx project, official support for Python 3.5
+has been removed from this project. However, please note that the only place
+this dependency is needed is for Sphinx document generation. The badgr-lite
+library itself has been tested with Python 3.5.
+
 Quick Start
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -25,20 +25,27 @@ Automate awarding Open Badges to recipients without the overhead of a server
 Python support
 --------------
 
-The actual library should work in Python 3.5, 3.6 and 3.7. However, the
-development support for documentation (i.e., Sphinx) has removed Python 3.5
-support.
+The badgr-lite library and command-line (CLI) should work in Python 3.5, 3.6
+and 3.7. You should be able to use this without error in those versions (and
+possibly other versions) as long as you do not need to regenerate the
+documentation. Generating the documentation shouldn't be needed as they are
+already generated and online at `Read The Docs
+<https://badgr-lite.readthedocs.io/en/latest/>`_
+
+However, the documentation generation (i.e., Sphinx) support has removed Python
+3.5 support. These are considered developer only requirements.
 
 The Sphinx library requires snowballstemmer >= 1.1. However, snowballstemmer
 2.0.0 was just released. That update to snowballtemmer fails with Python 3.5
 due to a dependency with Python 3.6 or higher:
 
-```RuntimeError: yarl 1.4+ requires Python 3.6+```
+``RuntimeError: yarl 1.4+ requires Python 3.6+``
 
 Until this is resolved with the Sphinx project, official support for Python 3.5
 has been removed from this project. However, please note that the only place
 this dependency is needed is for Sphinx document generation. The badgr-lite
-library itself has been tested with Python 3.5.
+library itself has been tested with Python 3.5 and may work with other Python 3
+versions.
 
 Quick Start
 -----------


### PR DESCRIPTION
Issue: https://github.com/glenjarvis/badgr-lite/issues/25

(2nd PR to fix)

Although the tox file was updated in the previous build, the travis file was not. This should fix Issue #25 .