### PR TITLE
New Change in Badge Object (Issue #722)

### DIFF
--- a/badgr_lite/models.py
+++ b/badgr_lite/models.py
@@ -27,7 +27,7 @@ class Badge:
     # There are enough public methods; pylint: disable=R0903
     # Attrs are dynamically assigned;  pylint: disable=E1101
 
-    REQUIRED_JSON = ['entityId', 'expires', 'entityType', 'extensions',
+    REQUIRED_JSON = ['entityId', 'expires',
                      'openBadgeId', 'createdBy', 'issuer', 'image',
                      'issuerOpenBadgeId', 'createdAt']
     REQUIRED_ATTRS = [pythonic(attr) for attr in REQUIRED_JSON]


### PR DESCRIPTION
In Badgr website they have changed the way they send the badge json. Now, there aren't entity_type nor extensions.

The following error is raised:

packages\badgr_lite\models.py", line 68, in _check_missing_but_required
raise exceptions.RequiredAttributesMissingError(
badgr_lite.exceptions.RequiredAttributesMissingError: extensions, entity_type

Proposed solution that worked for me: change model for Badge object:
1- go to models.py
2- delete from REQUIRED_JSON the strings "entityType" and "extensions"

Now it works